### PR TITLE
Add DAX.exe-running startup gate

### DIFF
--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -59,9 +59,27 @@ public partial class MainWindow : Window
             _subscribedVm.PropertyChanged += OnViewModelPropertyChanged;
     }
 
-    private void OnMainWindowOpened(object? sender, EventArgs e)
+    private async void OnMainWindowOpened(object? sender, EventArgs e)
     {
+        await EnsureDaxRunningAsync();
         TryShowFirstInstallWizard();
+    }
+
+    private async Task EnsureDaxRunningAsync()
+    {
+        while (true)
+        {
+            if (Process.GetProcessesByName("DAX").Length > 0)
+            {
+                _subscribedVm?.AddStreamerStatus("DAX.exe is running.");
+                return;
+            }
+
+            _subscribedVm?.AddStreamerStatus("DAX.exe not found.");
+            bool retry = await ShowDaxNotRunningDialogAsync();
+            if (!retry)
+                return;
+        }
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -352,6 +370,67 @@ public partial class MainWindow : Window
 
         okButton.Click += (_, _) => dialog.Close();
         await dialog.ShowDialog(this);
+    }
+
+    private async Task<bool> ShowDaxNotRunningDialogAsync()
+    {
+        var message = new TextBlock
+        {
+            Text = "Please start or ensure DAX is running",
+            TextWrapping = TextWrapping.Wrap,
+            MaxWidth = 400
+        };
+
+        bool retryClicked = false;
+
+        var retryButton = new Button
+        {
+            Content = "Retry",
+            MinWidth = 80
+        };
+
+        var ignoreButton = new Button
+        {
+            Content = "Ignore",
+            MinWidth = 80,
+            IsDefault = true
+        };
+
+        var dialog = new Window
+        {
+            Title = "Dax.exe Not Running Error",
+            Width = 440,
+            SizeToContent = SizeToContent.Height,
+            CanResize = false,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Content = new StackPanel
+            {
+                Margin = new Thickness(16),
+                Spacing = 14,
+                Children =
+                {
+                    message,
+                    new StackPanel
+                    {
+                        Orientation = Avalonia.Layout.Orientation.Horizontal,
+                        HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right,
+                        Spacing = 8,
+                        Children = { retryButton, ignoreButton }
+                    }
+                }
+            }
+        };
+
+        retryButton.Click += (_, _) =>
+        {
+            retryClicked = true;
+            dialog.Close();
+        };
+
+        ignoreButton.Click += (_, _) => dialog.Close();
+
+        await dialog.ShowDialog(this);
+        return retryClicked;
     }
 
 }

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -69,7 +69,7 @@ public partial class MainWindow : Window
     {
         while (true)
         {
-            if (Process.GetProcessesByName("DAX").Length > 0)
+            if (IsDaxRunning())
             {
                 _subscribedVm?.AddStreamerStatus("DAX.exe is running.");
                 return;
@@ -80,6 +80,13 @@ public partial class MainWindow : Window
             if (!retry)
                 return;
         }
+    }
+
+    private static bool IsDaxRunning()
+    {
+        var procs = Process.GetProcessesByName("DAX");
+        try { return procs.Length > 0; }
+        finally { foreach (var p in procs) p.Dispose(); }
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -393,7 +400,8 @@ public partial class MainWindow : Window
         {
             Content = "Ignore",
             MinWidth = 80,
-            IsDefault = true
+            IsDefault = true,
+            IsCancel = true
         };
 
         var dialog = new Window

--- a/MainWindowViewModel.cs
+++ b/MainWindowViewModel.cs
@@ -1291,7 +1291,7 @@ private static readonly (string ReleaseTag, string CommitHash, string Display, s
         FooterStatusText = _footerStatusBuffer.Add(message);
     }
 
-    private void AddStreamerStatus(string message)
+    internal void AddStreamerStatus(string message)
     {
         AddFooterStatus($"[STREAMER] {message}");
         AppendStreamerLog(message);


### PR DESCRIPTION
Closes #29.

Adds a startup gate that checks for the DAX.exe process when SmartStreamer4 launches. If DAX is not running, shows a modal dialog ("Dax.exe Not Running Error" / "Please start or ensure DAX is running") with Retry/Ignore. Retry rechecks; Ignore lets the app continue. Result is logged to the [STREAMER] panel and log file on every check.

**Why now:** dogfooding the contributing-guide workflow end-to-end against a real, small change.

**Tested:** field-tested on the dev box; happy-path log shows `DAX.exe is running.`, retry path shows `DAX.exe not found.` then `DAX.exe is running.` once DAX is started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new startup blocking loop and modal dialog on app open; risk is mainly UX/regression (potential to stall startup or create unexpected modal behavior), but no auth/data-path changes.
> 
> **Overview**
> Adds a startup gate in `MainWindow` that checks for a running `DAX.exe` process when the app opens; if missing, a modal "Dax.exe Not Running Error" dialog prompts **Retry** (re-check) or **Ignore** (continue).
> 
> Each check now logs status to the footer/log via `[STREAMER]` messages, which required widening `MainWindowViewModel.AddStreamerStatus` visibility to `internal` so the window can emit those messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d13633086dac7f095d08f35027115ba209caf836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->