### PR TITLE
Revise CONTRIBUTING.md based on #29 dogfooding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,42 +25,50 @@ git checkout main && git pull
 
 ### 2. Create a focused branch
 
-Name it after what it does:
+Name it after what it does and include the issue number when available. Use the bare number — no `#` — because `#` becomes `%23` in GitHub URLs:
 
 ```
-git checkout -b fix/dax-iq-restart-on-band-change
-git checkout -b feature/skimmer-port-config
+git checkout -b fix/29-dax-not-running-gate
+git checkout -b feature/42-skimmer-port-config
 ```
+
+Save the `#` for commit messages and PR titles, where GitHub auto-links to the issue.
 
 Keep each branch to one bug or one feature. Small scope = fast review.
 
 ### 3. Make your changes
 
-Run these gates before committing — both must pass:
+Run these gates before committing — all must pass:
 
 ```
-dotnet build -warnaserror
-dotnet test
+dotnet build SmartSDRIQStreamer.csproj
+dotnet test tests/SmartSDRIQStreamer.CWSkimmer.Tests
 ```
+
+`dotnet test` from the repo root finds nothing because there's no `.sln` file — point it at a folder that contains a test csproj.
+
+Then live-test the change in the running app. Unit tests verify code correctness, not feature correctness — exercise the change against real hardware (radio + DAX + CW Skimmer as relevant) before moving on.
 
 ### 4. Commit
 
 Stage specific files rather than `git add -A`:
 
 ```
-git add src/CwSkimmerWorkflowService.cs
-git commit -m "restart DAX-IQ stream when slice changes bands"
+git add MainWindow.axaml.cs MainWindowViewModel.cs
+git commit -m "Add DAX.exe-running startup gate (#29)"
 ```
 
-Write commit messages that explain *why*, not just *what*. The diff shows what changed.
+Write commit messages that explain *why*, not just *what*. The diff shows what changed. Reference the issue number with `(#N)` so the commit links back from the git log and shows up on the issue thread.
+
+**Tangential edits picked up along the way?** Don't include them in this PR. Either stash them (`git stash push -- <file>`) and handle them on their own branch + PR, or leave them in your working tree and tackle them after this branch wraps up. Keep each PR focused on one bug or one feature.
 
 ### 5. Push and open a pull request
 
 Collaborators:
 
 ```
-git push -u origin fix/dax-iq-restart-on-band-change
-gh pr create --base main --title "Restart DAX-IQ stream on band change" --body "..."
+git push -u origin fix/29-dax-not-running-gate
+gh pr create --base main --title "Add DAX.exe-running startup gate" --body "..."
 ```
 
 Outside contributors: push to your fork and open the PR from the GitHub UI against `cdub89/SmartStreamer4:main`.
@@ -69,8 +77,26 @@ PR body should explain the motivation and any alternatives considered. A short p
 
 ### 6. Review
 
-- **Claude**: type `/ultrareview <PR#>` in Claude Code for a full multi-angle code review, or `/review` for a lighter pass.
-- **@cdub89**: reviews and approves before merge.
+Reviewer (@cdub89) will either approve the PR or request changes. Run a Claude review pass first to catch obvious issues:
+
+- `/ultrareview <PR#>` — full multi-agent cloud review (more thorough, billed)
+- `/review <PR#>` — lighter pass; **output stays in your local Claude Code session and is not posted to the PR.** Use it as a triage aid, then either leave your own review comments on GitHub, or copy the relevant findings into a PR comment with `gh pr review <PR#> --comment --body "..."` if you want the contributor to see them verbatim.
+
+**Fixing issues on behalf of the contributor:**
+
+For small fixes (typos, missing disposes, formatting), use GitHub's "Suggested change" UI in a review comment — the contributor clicks "Commit suggestion" and it's applied to their branch with full attribution. Don't silently push commits to a contributor's branch — if you must push a fix yourself, leave a top-level PR comment explaining *what* you changed and *why* so the contributor isn't surprised when they pull.
+
+**After review — what to expect as the PR author:**
+
+*Listed collaborators (branches in this repo):*
+
+- *Approved:* you squash-merge into `main` yourself — either via GitHub's "Squash and merge" button on the PR page, or `gh pr merge <PR#> --squash --delete-branch`.
+- *Changes requested:* address each comment, push follow-up commits to the same branch (no force-push, no amend). Leave a brief PR comment summarizing what you addressed so the review → fix trail is visible later. Then click "Re-request review" on the PR. Iterate until approved, then merge.
+
+*Outside contributors (branches on your fork):*
+
+- *Approved:* @cdub89 merges into `main`. After the merge, delete the branch on your fork (GitHub will prompt you).
+- *Changes requested:* address each comment, push follow-up commits to your fork's branch (the PR updates automatically). Leave a brief PR comment summarizing what you addressed so the review → fix trail is visible later. Click "Re-request review". Iterate until @cdub89 approves and merges.
 
 ## Reporting Bugs
 


### PR DESCRIPTION
Revises CONTRIBUTING.md based on gaps surfaced while running issue #29 end-to-end as a dogfood test of the workflow.

## Changes

- **Step 2** — branch names use bare issue number (`fix/29-...`) instead of `fix/#29-...`, since `#` URL-encodes to `%23` in GitHub paths.
- **Step 3** — added live-test as a third gate (unit tests verify code correctness, not feature correctness); fixed build command to target `SmartSDRIQStreamer.csproj` and test command to target a folder that contains a test csproj (plain `dotnet test` finds nothing because there's no .sln); dropped `-warnaserror` (FlexLib emits warnings we don't control).
- **Step 4** — commit example shows `(#N)` reference convention; new note on what to do with tangential edits picked up along the way.
- **Step 5** — push example matches the new step 2 convention.
- **Step 6** — clarified that `/review` output is local-only and not posted to the PR; added "Fixing issues on behalf of the contributor" subsection (use Suggested Change UI; don't silently push to a contributor's branch); split after-review expectations by collaborator vs. outside-contributor paths; added follow-up-commit etiquette (leave a brief PR comment summarizing what was addressed).

## Why now

This is the second cycle of dogfooding the contributing workflow. #29 was the first — it surfaced the gaps above as we hit them in real time. The guide now reflects the workflow we actually want, written for newer developers who may not have used GitHub extensively in a group project.

## Tested

- `dotnet build SmartSDRIQStreamer.csproj` — 0 errors, 64 FlexLib warnings (baseline noise).
- `dotnet test tests/SmartSDRIQStreamer.CWSkimmer.Tests` — 35 passed, 0 failed.
- Live test: not applicable (doc-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)